### PR TITLE
added call to nkdist:wait_for_service/0

### DIFF
--- a/src/nkdomain_app.erl
+++ b/src/nkdomain_app.erl
@@ -88,6 +88,8 @@ start(_Type, _Args) ->
     case nklib_config:load_env(?APP, Syntax) of
         {ok, _} ->
             {ok, Pid} = nkdomain_sup:start_link(),
+            lager:info("waiting for nkdist"),
+            nkdist:wait_for_service(),
             %% ok = riak_core_ring_events:add_guarded_handler(nkdomain_ring_handler, []),
             {ok, Vsn} = application:get_key(nkdomain, vsn),
             lager:info("NkDOMAIN v~s has started.", [Vsn]),


### PR DESCRIPTION
Ensure nkdist is ready by calling nkdist:wait_for_service/0, before attempting to register classes/types. This prevents a race condition detected when starting nkdomain within a release. 