### PR TITLE
restored call to nkdist:wait_for_service/0

### DIFF
--- a/src/nkdomain_app.erl
+++ b/src/nkdomain_app.erl
@@ -89,7 +89,9 @@ start(_Type, _Args) ->
         {ok, _} ->
             {ok, Pid} = nkdomain_sup:start_link(),
             %% lager:info("waiting for nkdist"),
-            %% nkdist:wait_for_service(),
+            %% important -- we need to tell nkdist to wait for riak
+            %% core to be fully initialized and ready
+            nkdist:wait_for_service(),
             %% ok = riak_core_ring_events:add_guarded_handler(nkdomain_ring_handler, []),
             {ok, Vsn} = application:get_key(nkdomain, vsn),
             lager:info("NkDOMAIN v~s has started.", [Vsn]),


### PR DESCRIPTION
Restore call to nkdist:wait_for_service so that we properly wait for riak_core's async initialization before starting to register services