### PR TITLE
Fixed user presence by sending an "offline" status by default

### DIFF
--- a/src/objs/core/nkdomain_user_obj.erl
+++ b/src/objs/core/nkdomain_user_obj.erl
@@ -615,7 +615,7 @@ object_sync_op({?MODULE, get_name, Opts}, _From, #?STATE{obj=Obj}=State) ->
                         {ok, UserPres} ->
                             Acc#{Type => UserPres};
                         {error, _} ->
-                            Acc
+                            Acc#{Type => #{status => <<"offline">>}}
                     end
                 end,
                 #{},


### PR DESCRIPTION
This happens when the user is neither "online" nor "inactive"