### PR TITLE
Fixed fullname in user_updated event.

### DIFF
--- a/src/objs/core/nkdomain_user_obj.erl
+++ b/src/objs/core/nkdomain_user_obj.erl
@@ -395,7 +395,7 @@ sync_op({get_info, Opts}, _From, #obj_state{obj=Obj}=State) ->
     Data = Base#{
         name => UserName,
         surname => UserSurName,
-        fullname => maps:get(name, Obj, UserName),
+        fullname => <<UserName/binary, " ", UserSurName/binary>>,
         email => maps:get(email, User, <<>>),
         phone_t => maps:get(phone_t, User, <<>>),
         address_t => maps:get(address_t, User, <<>>),


### PR DESCRIPTION
This event contained the original fullname instead of the updated version when changing a user name or surname