### PR TITLE
Added a small patch to fix VOIP Push in v1-tmp.

### DIFF
--- a/src/objs/core/nkdomain_user_obj.erl
+++ b/src/objs/core/nkdomain_user_obj.erl
@@ -945,7 +945,9 @@ do_send_push(SrvId, Push, State) ->
 find_push_devices(SrvId, State) ->
     #obj_state{session=Session} = State,
     #session{push_devices=Devices} = Session,
-    [Device || #push_device{srv_id=S}=Device <- Devices, S==SrvId].
+    % TODO: Temporal fix to send a push to all registered devices
+    %[Device || #push_device{srv_id=S}=Device <- Devices, S==SrvId].
+    Devices.
 
 
 %% @private


### PR DESCRIPTION
Instead of filtering the device list by service id, we send all registered devices saved for that user