### PR TITLE
add objects/domain/delete_childs_of_type api call

### DIFF
--- a/src/objs/core/nkdomain_domain_obj_cmd.erl
+++ b/src/objs/core/nkdomain_domain_obj_cmd.erl
@@ -130,6 +130,16 @@ cmd(<<"unload_childs">>, #nkreq{data=Data}=Req) ->
             Error
     end;
 
+
+cmd(<<"delete_childs_of_type">>, #nkreq{data=#{ type := Type }=Data}=Req) ->
+    case get_domain(Data, Req) of
+        {ok, Id} ->
+		nkdomain:remove_path_type(Id, Type),
+		{ok, #{}};
+        Error ->
+            Error
+   end;
+
 cmd(Cmd, Req) ->
     nkdomain_obj_cmd:cmd(Cmd, ?DOMAIN_DOMAIN, Req).
 

--- a/src/objs/core/nkdomain_domain_obj_cmd.erl
+++ b/src/objs/core/nkdomain_domain_obj_cmd.erl
@@ -140,6 +140,15 @@ cmd(<<"delete_childs_of_type">>, #nkreq{data=#{ type := Type }=Data}=Req) ->
             Error
    end;
 
+cmd(<<"create_child">>, #nkreq{data=#{ path := Path, data := ChildData }=Data}=Req) ->
+   Obj = ChildData#{ path => Path },
+   case nkdomain_obj_make:create(Obj) of 
+	{ok, #obj_id_ext{obj_id=ObjId}, _} ->
+	    {ok, #{ id => ObjId }};
+	Error -> 
+	    Error
+   end; 
+
 cmd(Cmd, Req) ->
     nkdomain_obj_cmd:cmd(Cmd, ?DOMAIN_DOMAIN, Req).
 

--- a/src/objs/core/nkdomain_domain_obj_syntax.erl
+++ b/src/objs/core/nkdomain_domain_obj_syntax.erl
@@ -83,6 +83,12 @@ syntax(<<"delete_childs_of_type">>, Syntax) ->
 	type => binary
     };
 
+syntax(<<"create_child">>, Syntax) ->
+    Syntax#{
+        path => binary,
+	data => map
+    };
+
 syntax(Cmd, Syntax) ->
     nkdomain_obj_syntax:syntax(Cmd, ?DOMAIN_DOMAIN, Syntax).
 

--- a/src/objs/core/nkdomain_domain_obj_syntax.erl
+++ b/src/objs/core/nkdomain_domain_obj_syntax.erl
@@ -76,6 +76,13 @@ syntax(<<"unload_childs">>, Syntax) ->
         id => binary
     };
 
+
+syntax(<<"delete_childs_of_type">>, Syntax) ->
+    Syntax#{
+        id => binary,
+	type => binary
+    };
+
 syntax(Cmd, Syntax) ->
     nkdomain_obj_syntax:syntax(Cmd, ?DOMAIN_DOMAIN, Syntax).
 


### PR DESCRIPTION
Added api call: **objects/domain/delete_childs_of_type.**
Purpose: for test automation, in order to make scenarios repeatable, and also in order to test edge scenarios where there is no data.

Example:

```
POST
{
cmd: "objects/domain/delete_childs_of_type",
data: {
id: "/sphera",
type: "med.consent"
}
}
```