### PR TITLE
V09 admin access

### DIFF
--- a/src/nkdomain_admin_util.erl
+++ b/src/nkdomain_admin_util.erl
@@ -30,6 +30,7 @@
 -export([make_type_view_id/2, make_type_view_filter/2, make_obj_view_id/2, make_view_subview_id/3]).
 -export([make_confirm/2, make_msg/2, make_msg_ext/4, get_domains/2]).
 -export([get_size_bin/1]).
+-export([is_authorized/1]).
 
 -include("nkdomain.hrl").
 -include("nkdomain_admin.hrl").
@@ -286,6 +287,20 @@ get_size_bin(Size) ->
         _ ->
             Rest2 = get_chars_from_binary(2, 2, nklib_util:to_binary(Rest)),
             <<(nklib_util:to_binary(Integer))/binary, ".", Rest2/binary, Tag/binary>>
+    end.
+
+
+%% @doc
+is_authorized(<<"admin">>) ->
+    true;
+
+is_authorized(UserId) ->
+    case nkdomain:get_obj(UserId) of
+        {ok, User} ->
+            Tags = maps:get(tags, User, []),
+            lists:member(<<"admin">>, Tags);
+        {error, _Error} ->
+            false
     end.
 
 


### PR DESCRIPTION
- Disabled admin user modifications for all users except the admin user itself.
- Allowed admin user and all users with the "admin" tag to start an admin session. The rest of the users will receive an "unauthorized" error.