### PR TITLE
Added a form for domains.

### DIFF
--- a/src/nkdomain_admin_detail.erl
+++ b/src/nkdomain_admin_detail.erl
@@ -44,7 +44,8 @@ element_action([?ADMIN_OBJ_TYPE, Path, Type], selected, _Value, Updates, Session
     {ok, Updates2, Session2};
 
 element_action([?ADMIN_OBJ_ID, ObjId, Type, Path], selected, Value, Updates, Session) ->
-    {Updates2, Session2} = selected_obj(ObjId, Type, Path, Updates, Session),
+    IsObjId = maps:get(is_obj_id, Value, false),
+    {Updates2, Session2} = selected_obj(ObjId, Type, Path, IsObjId, Updates, Session),
     case Value of
         #{update_url:=true} ->
             {Updates3, Session3} = nkadmin_util:update_url(Updates2, Session2),
@@ -181,7 +182,7 @@ selected_type(Type, Path, Updates, Session) ->
 selected_obj(ObjId, Updates, Session) ->
     case nkdomain_db:find(ObjId) of
         #obj_id_ext{type=Type, path=Path} ->
-            selected_obj(ObjId, Type, Path, Updates, Session);
+            selected_obj(ObjId, Type, Path, false, Updates, Session);
         {error, Error} ->
             ?LLOG(notice, "error reading object ~s (~p)", [ObjId, Error], Session),
             {ok, Updates, Session}
@@ -189,10 +190,10 @@ selected_obj(ObjId, Updates, Session) ->
 
 
 %% @doc
-selected_obj(_ObjId, ?DOMAIN_DOMAIN, ObjPath, Updates, Session) ->
+selected_obj(_ObjId, ?DOMAIN_DOMAIN, ObjPath, false, Updates, Session) ->
     selected_type(?DOMAIN_DOMAIN, ObjPath, Updates, Session);
 
-selected_obj(ObjId, Type, ObjPath, Updates, Session) ->
+selected_obj(ObjId, Type, ObjPath, _Value, Updates, Session) ->
     case nkdomain:get_obj(ObjId) of
         {ok, Obj} ->
             case call_obj_view(Type, view, [Obj, false], Session) of

--- a/src/objs/admin/nkadmin_session_obj.erl
+++ b/src/objs/admin/nkadmin_session_obj.erl
@@ -247,7 +247,13 @@ object_sync_op({?MODULE, element_action, <<"url">>, updated, Url}, _From, State)
     #obj_state{session=Session} = State,
     case find_url(Url, Session) of
         {ok, Parts} ->
-            case do_element_action(Parts, selected, #{update_url=>false}, State) of
+            IsObjId = case Url of
+                <<"_id/", _/binary>> ->
+                    true;
+                _ ->
+                    false
+            end,
+            case do_element_action(Parts, selected, #{is_obj_id => IsObjId, update_url=>false}, State) of
                 {ok, Reply, State2} ->
                     {reply, {ok, Reply}, State2};
                 {error, Error, State2} ->
@@ -407,7 +413,13 @@ do_get_domain_detail(Updates, Session, State) ->
     #admin_session{url=Url} = Session,
     case find_url(Url, Session) of
         {ok, Parts} ->
-            case handle(admin_element_action, [Parts, selected, <<>>, Updates], Session) of
+            IsObjId = case Url of
+                <<"_id/", _/binary>> ->
+                    true;
+                _ ->
+                    false
+            end,
+            case handle(admin_element_action, [Parts, selected, #{is_obj_id => IsObjId}, Updates], Session) of
                 {ok, Updates2, Session2} ->
                     {ok, Updates2, Session2};
                 {error, Error, Session2} ->

--- a/src/objs/core/nkdomain_domain_obj.erl
+++ b/src/objs/core/nkdomain_domain_obj.erl
@@ -70,7 +70,8 @@ object_admin_info() ->
     #{
         %class => session,
         %weight => 2000,
-        type_view_mod => nkdomain_domain_obj_type_view
+        type_view_mod => nkdomain_domain_obj_type_view,
+        obj_view_mod => nkdomain_domain_obj_view
     }.
 
 

--- a/src/objs/core/nkdomain_domain_obj_type_view.erl
+++ b/src/objs/core/nkdomain_domain_obj_type_view.erl
@@ -39,13 +39,21 @@ view(Path, Session) ->
             },
             #{
                 id => domain,
-                fillspace => <<"1.5">>,
+                fillspace => <<"1.0">>,
                 type => text,
                 name => domain_column_domain,
                 is_html => true,
                 sort => true,
                 is_html => true,
                 options => get_agg_name(<<"domain_id">>, Path, Session)
+            },
+            #{
+                id => obj_name,
+                type => text,
+                fillspace => <<"0.5">>,
+                name => domain_column_id,
+                sort => true,
+                is_html => true % Will allow us to return HTML inside the column data
             },
             #{
                 id => name,

--- a/src/objs/core/nkdomain_domain_obj_view.erl
+++ b/src/objs/core/nkdomain_domain_obj_view.erl
@@ -1,0 +1,176 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2017 Carlos Gonzalez Florido.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Domain Object
+
+-module(nkdomain_domain_obj_view).
+-author('Carlos Gonzalez <carlosj.gf@gmail.com>').
+
+-export([view/3, update/3, create/2]).
+
+-include("nkdomain.hrl").
+-include("nkdomain_admin.hrl").
+-include_lib("nkadmin/include/nkadmin.hrl").
+
+
+-define(LLOG(Type, Txt, Args),
+    lager:Type("NkDOMAIN Admin Domain " ++ Txt, Args)).
+
+
+
+
+%% @private
+view(Obj, IsNew, #admin_session{user_id=UserId, domain_id=Domain}=Session) ->
+    ObjId = maps:get(obj_id, Obj, <<>>),
+    DomainId = maps:get(domain_id, Obj, Domain),
+    ObjName = maps:get(obj_name, Obj, <<>>),
+    Name = maps:get(name, Obj, <<>>),
+    Description = maps:get(description, Obj, <<>>),
+    Enabled = maps:get(enabled, Obj, true),
+    Tags = maps:get(tags, Obj, []),
+    IconId = maps:get(icon_id, Obj, <<>>),
+    IconUrl = case IconId of
+        <<>> ->
+            <<"img/question_mark.png">>;
+        IconId ->
+            nkdomain_admin_util:get_file_url(IconId, Session)
+    end,
+    IconImage = <<"<img class='photo' style='padding: 0px 10% 0 10%; width:80%; height:auto;' src='", IconUrl/binary, "'/>">>,
+    FormId = nkdomain_admin_util:make_obj_view_id(?DOMAIN_DOMAIN, ObjId),
+    Base = case IsNew of
+        true ->
+            #{};
+        false ->
+            #{with_image => IconImage, with_css => <<"photo">>, with_file_types => ["png", "jpg", "jpeg"]}
+    end,
+    Spec = Base#{
+        form_id => FormId,
+        buttons => [
+            #{type => case Enabled of true -> disable; _ -> enable end, disabled => IsNew},
+            #{type => delete, disabled => IsNew},
+            #{type => save}
+        ],
+        groups => [
+            #{
+                header => ?DOMAIN_DOMAIN,
+                values => [
+                    case IsNew of
+                        true ->
+                            {ok, Domains} = nkdomain_admin_util:get_domains("/", Session),
+                            Opts = [
+                                #{id=>Id, value=>Value} ||
+                                {Id, Value} <- [{<<"root">>, <<"/">>}|Domains]
+                            ],
+                            #{
+                                id => <<"domain">>,
+                                type => combo,
+                                label => <<"Domain">>,
+                                value => DomainId,
+                                editable => true,
+                                options => Opts
+                            };
+                        false ->
+                            DomainPath = case nkdomain_db:find(DomainId) of
+                                #obj_id_ext{path=DP} -> DP;
+                                _ -> <<>>
+                            end,
+                            #{
+                                id => <<"domain">>,
+                                type => text,
+                                label => <<"Domain">>,
+                                value => DomainPath,
+                                editable => false
+                            }
+                    end,
+                    #{
+                        id => <<"obj_name">>,
+                        type => text,
+                        label => <<"Object name">>,
+                        value => ObjName,
+                        required => IsNew,
+                        editable => IsNew
+                    },
+                    #{
+                        id => <<"name">>,
+                        type => text,
+                        label => <<"Name">>,
+                        value => Name,
+                        required => true,
+                        editable => true
+                    },
+                    #{
+                        id => <<"description">>,
+                        type => text,
+                        label => <<"Description">>,
+                        value => Description,
+                        editable => true
+                    }
+                ]
+            },
+            nkadmin_webix_form:creation_fields(Obj, IsNew)
+        ]
+    },
+    Data = #{
+        id => FormId,
+        class => webix_ui,
+        value => nkadmin_webix_form:form(Spec, ?DOMAIN_DOMAIN, Session)
+    },
+    {ok, Data, Session}.
+
+
+
+
+
+update(ObjId, Data, #admin_session{user_id=UserId}=_Session) ->
+    ?LLOG(info, "NKLOG UPDATE ~p ~p", [ObjId, Data]),
+    Base = maps:with([<<"name">>, <<"description">>, <<"icon_id">>], Data),
+    case nkdomain:update(ObjId, Base) of
+        {ok, _} ->
+            ?LLOG(notice, "domain ~s updated", [ObjId]),
+            ok;
+        {error, Error} ->
+            ?LLOG(notice, "could not update domain ~s: ~p", [ObjId, Error]),
+            {error, Error}
+    end.
+
+
+create(Data, _Session) ->
+    ?LLOG(info, "NKLOG CREATE ~p", [Data]),
+    #{
+        <<"domain">> := DomainId,
+        <<"obj_name">> := ObjName,
+        <<"name">> := Name,
+        <<"description">> := Description
+    } = Data,
+    DomainCreate = #{
+        type => ?DOMAIN_DOMAIN,
+        domain_id => DomainId,
+        obj_name => ObjName,
+        name => Name,
+        description => Description,
+        ?DOMAIN_DOMAIN => #{}
+    },
+    case nkdomain_obj_make:create(DomainCreate) of
+        {ok, #obj_id_ext{obj_id=ObjId}, [<<"domain.config">>]} ->
+            {ok, ObjId};
+        {error, Error} ->
+            {error, Error}
+    end.
+


### PR DESCRIPTION
If the domain obj_id is used in the URL, then the domain form is shown.
If the domain path is used in the URL, then a datatable with the list of domains below that path is shown instead.
There's still an issue when deleting a domain, because it will be kept in the sidebar domain list until a new domain is created.