### PR TITLE
Added default channels selection to domains.

### DIFF
--- a/src/nkdomain_admin_util.erl
+++ b/src/nkdomain_admin_util.erl
@@ -30,7 +30,7 @@
 -export([make_type_view_id/2, make_type_view_filter/2, make_obj_view_id/2, make_view_subview_id/3]).
 -export([make_confirm/2, make_msg/2, make_msg_ext/4, get_domains/2]).
 -export([get_size_bin/1]).
--export([is_authorized/1]).
+-export([is_authorized/1, get_client_id/1]).
 
 -include("nkdomain.hrl").
 -include("nkdomain_admin.hrl").
@@ -303,6 +303,23 @@ is_authorized(UserId) ->
             false
     end.
 
+
+%% @doc
+get_client_id(#admin_session{srv_id=SrvId}=Session) ->
+    SrvIdBin = nklib_util:to_binary(SrvId),
+    case SrvIdBin of
+        <<"dkv", _/binary>> ->
+            <<"dkv">>;
+        <<"mde", _/binary>> ->
+            <<"mde">>;
+        <<"sipstorm", _/binary>> ->
+            <<"sipstorm">>;
+        <<"sphera", _/binary>> ->
+            <<"sphera">>;
+        _ ->
+            <<"sipstorm">>
+    end.
+        
 
 %% @private
 get_chars_from_binary(Start, Chars, <<_C/utf8, Bin/binary>>) when Start > 0 ->

--- a/src/objs/core/nkdomain_domain_obj_view.erl
+++ b/src/objs/core/nkdomain_domain_obj_view.erl
@@ -29,6 +29,7 @@
 -include("nkdomain_admin.hrl").
 -include_lib("nkadmin/include/nkadmin.hrl").
 
+-define(CHAT_CONVERSATION, <<"conversation">>).
 
 -define(LLOG(Type, Txt, Args),
     lager:Type("NkDOMAIN Admin Domain " ++ Txt, Args)).
@@ -37,9 +38,9 @@
 
 
 %% @private
-view(Obj, IsNew, #admin_session{user_id=UserId, domain_id=Domain}=Session) ->
+view(Obj, IsNew, #admin_session{user_id=UserId, domain_id=DefDomain, srv_id=SrvId}=Session) ->
     ObjId = maps:get(obj_id, Obj, <<>>),
-    DomainId = maps:get(domain_id, Obj, Domain),
+    DomainId = maps:get(domain_id, Obj, DefDomain),
     ObjName = maps:get(obj_name, Obj, <<>>),
     Name = maps:get(name, Obj, <<>>),
     Description = maps:get(description, Obj, <<>>),
@@ -53,6 +54,18 @@ view(Obj, IsNew, #admin_session{user_id=UserId, domain_id=Domain}=Session) ->
             nkdomain_admin_util:get_file_url(IconId, Session)
     end,
     IconImage = <<"<img class='photo' style='padding: 0px 10% 0 10%; width:80%; height:auto;' src='", IconUrl/binary, "'/>">>,
+    ClientId = nkdomain_admin_util:get_client_id(Session),
+    Domain = maps:get(?DOMAIN_DOMAIN, Obj, #{}),
+    Configs = maps:get(configs, Domain, #{}),
+    DefChanMap = maps:get(<<"default_channels_", ClientId/binary>>, Configs, #{<<"list">> => []}),
+    DefaultChannels = case DefChanMap of
+        #{<<"list">> := L} ->
+            L;
+        #{list := L} ->
+            L
+    end,
+    DefaultChannelsBin = lists:join(<<",">>, DefaultChannels),
+    DefaultChannelsOpts = get_convs_opts(DefaultChannels),
     FormId = nkdomain_admin_util:make_obj_view_id(?DOMAIN_DOMAIN, ObjId),
     Base = case IsNew of
         true ->
@@ -124,6 +137,27 @@ view(Obj, IsNew, #admin_session{user_id=UserId, domain_id=Domain}=Session) ->
                     }
                 ]
             },
+            #{
+                header => <<"CONFIGURATION">>,
+                hidden => IsNew,
+                values => [
+                    #{
+                        id => <<"default_channels">>,
+                        type => multicombo,
+                        label => <<"Default channels">>,
+                        value => DefaultChannelsBin,
+                        suggest_type => ?CHAT_CONVERSATION,
+                        suggest_field => <<"name">>,
+                        suggest_filters => #{
+                            conversation_type => <<"channel">>
+                        },
+                        suggest_template => <<"#name#">>,
+                        options => DefaultChannelsOpts,
+                        hidden => IsNew,
+                        editable => true
+                    }
+                ]
+            },
             nkadmin_webix_form:creation_fields(Obj, IsNew)
         ]
     },
@@ -138,13 +172,22 @@ view(Obj, IsNew, #admin_session{user_id=UserId, domain_id=Domain}=Session) ->
 
 
 
-update(ObjId, Data, #admin_session{user_id=UserId}=_Session) ->
+update(ObjId, Data, #admin_session{user_id=UserId}=Session) ->
     ?LLOG(info, "NKLOG UPDATE ~p ~p", [ObjId, Data]),
     Base = maps:with([<<"name">>, <<"description">>, <<"icon_id">>], Data),
+    DefaultChannels = maps:get(<<"default_channels">>, Data, []),
+    DefaultChannelsList = case binary:split(DefaultChannels, <<",">>, [global]) of
+        [<<>>] ->
+            [];
+        Other ->
+            Other
+    end,
+    DefChanMap = #{<<"list">> => DefaultChannelsList},
+    ClientId = nkdomain_admin_util:get_client_id(Session),
     case nkdomain:update(ObjId, Base) of
         {ok, _} ->
             ?LLOG(notice, "domain ~s updated", [ObjId]),
-            ok;
+            nkdomain_domain:set_config(ObjId, <<"default_channels_", ClientId/binary>>, DefChanMap);
         {error, Error} ->
             ?LLOG(notice, "could not update domain ~s: ~p", [ObjId, Error]),
             {error, Error}
@@ -174,3 +217,19 @@ create(Data, _Session) ->
             {error, Error}
     end.
 
+
+get_convs_opts(Ids) ->
+    get_convs_opts(Ids, []).
+
+%% @private
+get_convs_opts([], Acc) ->
+    lists:reverse(Acc);
+
+get_convs_opts([Id|Ids], Acc) ->
+    case nkdomain:get_name(Id) of
+        {ok, #{obj_id:=ObjId, name:=Name}} ->
+            get_convs_opts(Ids, [#{id => ObjId, name => Name} | Acc]);
+        {error, _Error} ->
+            ?LLOG(warning, "Unknown ID found: ~p", [Id]),
+            get_convs_opts(Ids, [#{id => Id, name => Id} | Acc])
+    end.

--- a/src/objs/core/nkdomain_user_obj_view.erl
+++ b/src/objs/core/nkdomain_user_obj_view.erl
@@ -54,8 +54,8 @@ view(Obj, IsNew, #admin_session{user_id=UserId, domain_id=Domain}=Session) ->
     end,
     IconImage = <<"<img class='photo' style='padding: 0px 10% 0 10%; width:80%; height:auto;' src='", IconUrl/binary, "'/>">>,
     FormId = nkdomain_admin_util:make_obj_view_id(?DOMAIN_USER, ObjId),
-    %IsAuthorized = ObjId =/= <<"admin">> orelse UserId =:= <<"admin">>,
-    IsAuthorized = ObjId =/= <<"admin">>,
+    IsAdminObj = ObjId =:= <<"admin">>,
+    IsAuthorized = (not IsAdminObj) orelse UserId =:= <<"admin">>,
     Base = case IsNew of
         true ->
             #{};
@@ -65,8 +65,8 @@ view(Obj, IsNew, #admin_session{user_id=UserId, domain_id=Domain}=Session) ->
     Spec = Base#{
         form_id => FormId,
         buttons => [
-            #{type => case Enabled of true -> disable; _ -> enable end, disabled => IsNew or (not IsAuthorized)},
-            #{type => delete, disabled => IsNew or (not IsAuthorized)},
+            #{type => case Enabled of true -> disable; _ -> enable end, disabled => IsNew or IsAdminObj},
+            #{type => delete, disabled => IsNew or IsAdminObj},
             #{type => save, disabled => not IsAuthorized}
         ],
         groups => [


### PR DESCRIPTION
- These default channels are saved in a configuration field for each domain, and are loaded from the user domain to the root domain (for /A/B/C/users/user, his/her list of default conversations will be given by the concatenation of default channels obtained for domains C, B, A, and root).
- Also changed the admin form to disable "delete" and "enable/disable" buttons.