### PR TITLE
Changed save_time to msec instead of secs.

### DIFF
--- a/src/nkdomain_obj.erl
+++ b/src/nkdomain_obj.erl
@@ -88,7 +88,7 @@
         type => nkdomain:type(),                        %% Mandatory!
         schema_type => nkdomain_graphql:schema_type(),
         permanent => boolean(),
-        save_time => integer(),                         %% secs
+        save_time => integer(),                         %% msecs
         default_ttl => integer(),                       %% msecs
         stop_after_disabled => boolean(),               %% Default false
         remove_after_stop => boolean(),

--- a/src/nkdomain_obj_util.erl
+++ b/src/nkdomain_obj_util.erl
@@ -287,7 +287,7 @@ set_next_status_timer(Time, #obj_state{obj=Obj, next_status_timer=Timer}=State) 
 
 %% @private
 do_save_timer(#obj_state{is_dirty=true, object_info=Info, save_timer=undefined}=State) ->
-    Time = 1000 * maps:get(save_time, Info, ?DEFAULT_SAVE_TIME),
+    Time = maps:get(save_time, Info, ?DEFAULT_SAVE_TIME),
     Ref = erlang:send_after(Time, self(), nkdomain_obj_save_timer),
     State#obj_state{timer=Ref};
 


### PR DESCRIPTION
This will make the default 5000 timeout value for saving objects to be 5 seconds instead of 5000 seconds.