### PR TITLE
Cleaned default conversation ids list and ignored empty mail.provider passwd

### DIFF
--- a/src/objs/core/nkdomain_domain_obj_view.erl
+++ b/src/objs/core/nkdomain_domain_obj_view.erl
@@ -332,7 +332,7 @@ update(ObjId, Data, #admin_session{user_id=UserId}=Session) ->
         [<<>>] ->
             [];
         Other ->
-            Other
+            lists:filter(fun(L) -> L =/= <<>> end, Other)
     end,
     DefConvMap = #{<<"list">> => DefaultConvsList},
     AlertIds = filter_by_prefix(<<"alert_message_">>, maps:keys(Data)),

--- a/src/objs/mail/nkdomain_mail_provider_obj_view.erl
+++ b/src/objs/mail/nkdomain_mail_provider_obj_view.erl
@@ -175,11 +175,17 @@ update(ObjId, Data, _Session) ->
         <<"password">> := Password,
         <<"force_tls">> := ForceTLS
     } = Data,
-    Config = maps:with([<<"relay">>, <<"username">>, <<"password">>, <<"force_tls">>], Data),
+    Config = maps:with([<<"relay">>, <<"username">>, <<"force_tls">>], Data),
+    Config2 = case Password of
+        <<>> ->
+            Config;
+        _ ->
+            Config#{password=>Password}
+    end,
     Update = #{
         <<"class">> => Class,
         <<"from">> => From,
-        <<"config">> => Config
+        <<"config">> => Config2
     },
     case nkdomain:update(ObjId, #{?DOMAIN_MAIL_PROVIDER => Update}) of
         {ok, _} ->


### PR DESCRIPTION
The list of default conversations for a given domain is now cleaned before saving. This is needed, because webix, for some reason, pass a list of empty values mixed with real conversation ids.

Also ignored the password field when updating a mail.provider. This will allow the user to edit a mail provider without submitting the password/API key