### PR TITLE
Allow updating file tags.

### DIFF
--- a/src/objs/file/nkdomain_file_obj.erl
+++ b/src/objs/file/nkdomain_file_obj.erl
@@ -187,8 +187,9 @@ http_post(Domain, StoreId, Name, Req) ->
     end.
 
 
-update(FileId, Data) -> 
-    nkdomain:update(FileId, #{?DOMAIN_FILE => Data}).
+update(FileId, Data) ->
+    Base = maps:with([tags], Data),
+    nkdomain:update(FileId, Base#{?DOMAIN_FILE => maps:without([tags], Data)}).
 
 
 %% @doc


### PR DESCRIPTION
"tags" field exists at the root level, so trying to update the tags of a certain file object wasn't possible.