### PR TITLE
Skipped unrecognized characters for name_norm field.

### DIFF
--- a/src/plugins/nkdomain_store_es_util.erl
+++ b/src/plugins/nkdomain_store_es_util.erl
@@ -253,7 +253,9 @@ unparse(#{type:=Type}=Obj) ->
     end,
     BaseMap3 = case BaseMap2 of
         #{name:=Name} ->
-            BaseMap2#{name_norm=>normalize_multi(Name)};
+            %BaseMap2#{name_norm=>normalize_multi(Name)};
+            % Ignore unrecognized characters
+            BaseMap2#{name_norm=>normalize_multi(Name, #{unrecognized=>skip})};
         _ ->
             BaseMap2
     end,


### PR DESCRIPTION
This will prevent a "json_error" after trying to save an object with a UTF-8 name that contains a character like "–"